### PR TITLE
Add Society API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 //	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.modelmapper:modelmapper:3.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'

--- a/src/main/java/org/ieeervce/gatekeeper/ItemNotFoundException.java
+++ b/src/main/java/org/ieeervce/gatekeeper/ItemNotFoundException.java
@@ -1,0 +1,18 @@
+package org.ieeervce.gatekeeper;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception raised if Item is not found
+ */
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ItemNotFoundException extends Exception {
+    /**
+     * Create an ItemFoundException with a message to present
+     * @param message Error message
+     */
+    public ItemNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/ieeervce/gatekeeper/config/ApplicationConfig.java
+++ b/src/main/java/org/ieeervce/gatekeeper/config/ApplicationConfig.java
@@ -1,0 +1,17 @@
+package org.ieeervce.gatekeeper.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ApplicationConfig {
+    /**
+     * A default modelmapper configuration.
+     * @return modelmapper instance
+     */
+    @Bean
+    public ModelMapper modelMapper(){
+        return new ModelMapper();
+    }
+}

--- a/src/main/java/org/ieeervce/gatekeeper/controller/SocietyController.java
+++ b/src/main/java/org/ieeervce/gatekeeper/controller/SocietyController.java
@@ -5,6 +5,7 @@ import org.ieeervce.gatekeeper.dto.SocietyDTO;
 import org.ieeervce.gatekeeper.entity.Society;
 import org.ieeervce.gatekeeper.service.SocietyService;
 import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,6 +16,7 @@ public class SocietyController {
     private final SocietyService societyService;
     private final ModelMapper modelMapper;
 
+    @Autowired
     public SocietyController(SocietyService societyService, ModelMapper modelMapper) {
         this.societyService = societyService;
         this.modelMapper = modelMapper;

--- a/src/main/java/org/ieeervce/gatekeeper/controller/SocietyController.java
+++ b/src/main/java/org/ieeervce/gatekeeper/controller/SocietyController.java
@@ -1,0 +1,49 @@
+package org.ieeervce.gatekeeper.controller;
+
+import org.ieeervce.gatekeeper.ItemNotFoundException;
+import org.ieeervce.gatekeeper.dto.SocietyDTO;
+import org.ieeervce.gatekeeper.entity.Society;
+import org.ieeervce.gatekeeper.service.SocietyService;
+import org.modelmapper.ModelMapper;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/society")
+public class SocietyController {
+    private final SocietyService societyService;
+    private final ModelMapper modelMapper;
+
+    public SocietyController(SocietyService societyService, ModelMapper modelMapper) {
+        this.societyService = societyService;
+        this.modelMapper = modelMapper;
+    }
+
+    @GetMapping
+    public List<Society> list(){
+        return societyService.list();
+    }
+
+    @PostMapping
+    public Society add(@RequestBody SocietyDTO societyDTO) {
+        Society society = modelMapper.map(societyDTO, Society.class);
+        return societyService.add(society);
+    }
+    @GetMapping("/{societyId}")
+    public Society findOne(@PathVariable int societyId) throws ItemNotFoundException {
+        return societyService.findOne(societyId);
+    }
+
+    @PutMapping("/{societyId}")
+    public Society edit(@PathVariable int societyId, @RequestBody SocietyDTO societyDTO) throws ItemNotFoundException {
+        Society society = modelMapper.map(societyDTO, Society.class);
+
+        return societyService.edit(societyId,society);
+    }
+
+    @DeleteMapping("/{societyId}")
+    public void delete(@PathVariable int societyId){
+        societyService.delete(societyId);
+    }
+}

--- a/src/main/java/org/ieeervce/gatekeeper/dto/SocietyDTO.java
+++ b/src/main/java/org/ieeervce/gatekeeper/dto/SocietyDTO.java
@@ -1,0 +1,34 @@
+package org.ieeervce.gatekeeper.dto;
+
+/**
+ * Society DTO to create/update a society.
+ */
+public class SocietyDTO {
+    private String name;
+    private String email;
+    private boolean active;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+}

--- a/src/main/java/org/ieeervce/gatekeeper/entity/Society.java
+++ b/src/main/java/org/ieeervce/gatekeeper/entity/Society.java
@@ -1,9 +1,12 @@
 package org.ieeervce.gatekeeper.entity;
+
 import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
-@Entity
 
+@Entity
 public class Society {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -13,13 +16,64 @@ public class Society {
     private String name;
 
     @Column(nullable = true)
-    private  String email;
+    private String email;
 
     @Column(nullable = false)
-    private  boolean isActive;
+    private boolean active;
 
+    @CreationTimestamp
     @Column(nullable = false)
-    private LocalDateTime dateTime;
+    private LocalDateTime createdAt;
 
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
 
+    public Integer getSocietyId() {
+        return societyId;
+    }
+
+    public void setSocietyId(Integer societyId) {
+        this.societyId = societyId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
 }

--- a/src/main/java/org/ieeervce/gatekeeper/repository/SocietyRepository.java
+++ b/src/main/java/org/ieeervce/gatekeeper/repository/SocietyRepository.java
@@ -1,0 +1,7 @@
+package org.ieeervce.gatekeeper.repository;
+
+import org.ieeervce.gatekeeper.entity.Society;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SocietyRepository extends JpaRepository<Society,Integer> {
+}

--- a/src/main/java/org/ieeervce/gatekeeper/service/SocietyService.java
+++ b/src/main/java/org/ieeervce/gatekeeper/service/SocietyService.java
@@ -1,0 +1,45 @@
+package org.ieeervce.gatekeeper.service;
+
+import jakarta.transaction.Transactional;
+import org.ieeervce.gatekeeper.ItemNotFoundException;
+import org.ieeervce.gatekeeper.entity.Society;
+import org.ieeervce.gatekeeper.repository.SocietyRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Create/Read/Update/Delete Societies
+ */
+@Service
+public class SocietyService {
+    static final String SOCIETY_ID_NOT_FOUND = "Society id not found: ";
+    private final SocietyRepository societyRepository;
+
+    public SocietyService(SocietyRepository societyRepository) {
+        this.societyRepository = societyRepository;
+    }
+
+    public List<Society> list(){
+        return societyRepository.findAll();
+    }
+    public Society add(Society society){
+        return societyRepository.save(society);
+    }
+    public Society findOne(int societyId) throws ItemNotFoundException {
+        return societyRepository.findById(societyId).orElseThrow(()->new ItemNotFoundException(SOCIETY_ID_NOT_FOUND + societyId));
+    }
+    @Transactional
+    public Society edit(int societyId, Society society) throws ItemNotFoundException {
+        Optional<Society> foundSocietyOptional = societyRepository.findById(societyId);
+        return foundSocietyOptional.map(foundSociety->{
+            society.setSocietyId(societyId);
+            society.setCreatedAt(foundSociety.getCreatedAt());
+            return societyRepository.save(society);
+        }).orElseThrow(()->new ItemNotFoundException(SOCIETY_ID_NOT_FOUND + societyId));
+    }
+    public void delete(int societyId){
+        societyRepository.deleteById(societyId);
+    }
+}

--- a/src/main/java/org/ieeervce/gatekeeper/service/SocietyService.java
+++ b/src/main/java/org/ieeervce/gatekeeper/service/SocietyService.java
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional;
 import org.ieeervce.gatekeeper.ItemNotFoundException;
 import org.ieeervce.gatekeeper.entity.Society;
 import org.ieeervce.gatekeeper.repository.SocietyRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,6 +18,7 @@ public class SocietyService {
     static final String SOCIETY_ID_NOT_FOUND = "Society id not found: ";
     private final SocietyRepository societyRepository;
 
+    @Autowired
     public SocietyService(SocietyRepository societyRepository) {
         this.societyRepository = societyRepository;
     }


### PR DESCRIPTION
### Summary

Added a Society API and convenience configurations.

### Changes


- Created required CRUD apis for Society.

- Added the `modelmapper` dependency. This allows us to use DTOs so that we can define what fields are taken as input (and not just the whole entity.
  - Modelmapper copies the matching properties from the DTO to the actual entity class. 
- Updated society field `isActive` to `active`. This is because the getter can be `isActive`, and still make sense.
- Update the society entity to have createdAt and updatedAt. These values will be automatically set by Hibernate, as required.
- Added an `ItemNotFoundException`. When this error is thrown, this will automatically map to a `404` response.
