### PR TITLE
Update Docker Base Container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17
+FROM eclipse-temurin:17-jre
 
 WORKDIR /app
 


### PR DESCRIPTION
Using a smaller base image will net us some space/time/bandwidth savings.

## Expected

~100MB smaller image. This should be a lot easier to pull with no degradation in functionality.

The image is smaller as anything outside of running the jar is stripped out of the java install. (There's JRE for running jars, JDK for the entire development env)

## Comparison

Note: we use `amd64` and `arm64/v8` images.

![Screenshot_2024-06-02_21-18-52](https://github.com/IEEE-RVCE/GateKeeper/assets/15711548/66c7d1d6-91a0-4a99-aaf0-384c93ed99ae)
![Screenshot_2024-06-02_21-18-25](https://github.com/IEEE-RVCE/GateKeeper/assets/15711548/5d5f4b31-3084-44c7-a638-519bf15092c7)
